### PR TITLE
Add form for making Procore API requests

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -116,7 +116,7 @@ GEM
       mini_portile2 (~> 2.4.0)
     popper_js (1.16.0)
     public_suffix (4.0.3)
-    puma (3.12.3)
+    puma (3.12.6)
     rack (2.2.2)
     rack-test (1.1.0)
       rack (>= 1.0, < 3)

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -72,7 +72,7 @@ class UsersController < ApplicationController
           { Authorization: "Bearer #{session[:oauth_response]['access_token']}" }
         )
       else
-        nil
+        ''
     end
 
 

--- a/app/views/users/home.html.erb
+++ b/app/views/users/home.html.erb
@@ -34,3 +34,40 @@
 <div class="revoke-button">
   <%= link_to "Revoke Your Access Token", login_revoke_path, method: :get, class: :button%>
 </div>
+
+<br/>
+<h1>Make a Procore API Request</h1>
+<%= form_with(url: '/users/home', method: 'get', local: true) do %>
+  <div class="form-group">
+    <label for="path">Path:</label>
+    <input id="path" type="text" name="path"></input>
+  </div>
+
+  <div class="form-group">
+    <label for="body">Body:</label>
+    <input id="body" type="textarea" name="body"></input>
+  </div>
+
+  <div class="form-group">
+    <label for="method">Method:</label>
+    <select id="method" type="text" name="method">
+      <option value="get">GET</option>
+      <option value="post">POST</option>
+    </select>
+  </div>
+
+  <input type="submit" class="btn btn-primary"></input>
+<% end %>
+
+<br/>
+<pre id="json-response"></pre>
+
+<script>
+  const resp = '<%= @resp.to_json.html_safe %>';
+
+  document.getElementById("json-response").textContent = JSON.stringify(
+    JSON.parse(resp),
+    undefined,
+    2
+  );
+</script>

--- a/app/views/users/home.html.erb
+++ b/app/views/users/home.html.erb
@@ -40,12 +40,12 @@
 <%= form_with(url: '/users/home', method: 'get', local: true) do %>
   <div class="form-group">
     <label for="path">Path:</label>
-    <input id="path" type="text" name="path"></input>
+    <input id="path" type="text" name="path" placeholder="/vapid/me"></input>
   </div>
 
   <div class="form-group">
     <label for="body">Body:</label>
-    <input id="body" type="textarea" name="body"></input>
+    <input id="body" type="textarea" name="body" placeholder="{}"></input>
   </div>
 
   <div class="form-group">


### PR DESCRIPTION
This PR adds a section at the bottom of the home page that enables users to make get/post requests to the procore API.  This is for usage in a demo for developers next week.

It also bumps our puma version as the one currently in the `Gemfile.lock` was pulled (I believe due to security concerns).

<img width="740" alt="screenshot" src="https://user-images.githubusercontent.com/7970552/85896772-f2dcc000-b7ad-11ea-95f8-54f083418a3a.png">