### PR TITLE
[ZL-871] Migrate to Rest v1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Within this file, configure your application's Client ID, Client Secret, and Red
         * OAUTH_URL: ''
         * BASE_URL: ''
 
-    * Client ID and Client Secret values are provided when [creating an application](https://developers.procore.com/documentation/new-application) in the Procore Developer Portal. The redirect URI above should be added to your application, which can be done on your application's home page.
+    * Client ID and Client Secret values are provided when [creating an application](https://developers.procore.com/documentation/new-application) in the Procore Developer Portal. The redirect URI above should be added to your application.
     * The BASE_URL and the OAUTH_URL will depend on which environment you're working accessing. If you're working in the production environment, the OAUTH_URL will be https://login.procore.com and the BASE_URL will be https://api.procore.com. For the sandbox environment, both the OAUTH_URL and the BASE_URL should be set to https://sandbox.procore.com.
     * After these values have been configured within the `application.yml` file, make sure to save your changes.
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -4,7 +4,7 @@ class UsersController < ApplicationController
   def me
     # Send a request to the Show User Info endpoint
     # Reference documentation: https://developers.procore.com/reference/me
-    get_me = RestClient.get(ENV['BASE_URL'] +'/vapid/me',
+    get_me = RestClient.get(ENV['BASE_URL'] +'/rest/v1.0/me',
             { Authorization: "Bearer #{session[:oauth_response]['access_token']}" })
 
     # Store the parsed response in an instance variable

--- a/app/views/users/home.html.erb
+++ b/app/views/users/home.html.erb
@@ -40,7 +40,7 @@
 <%= form_with(url: '/users/home', method: 'get', local: true) do %>
   <div class="form-group">
     <label for="path">Path:</label>
-    <input id="path" type="text" name="path" placeholder="/vapid/me"></input>
+    <input id="path" type="text" name="path" placeholder="/rest/v1.0/me"></input>
   </div>
 
   <div class="form-group">


### PR DESCRIPTION
Ticket: [ZL-871](https://procoretech.atlassian.net/browse/ZL-871)

Use `rest/v1.0` API routes instead of `vapid`. Also, removes an incorrect instruction about the redirect URI.

I've decided to split up this work from switching the application to use the Ruby SDK, which is in progress (https://github.com/procore/Procore-Sample-ROR/pull/14).